### PR TITLE
Improve architecture, fix storage bugs, add usability features

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,23 @@ curl https://your-worker.dev/raw/KEY
 | Save       | Ctrl+Enter / Ctrl+S |
 | New        | Alt+Shift+N         |
 | Duplicate  | Alt+Shift+D         |
+| Copy link  | Alt+Shift+C         |
+| View raw   | Alt+Shift+R         |
 | Share on X | Alt+Shift+X         |
+
+## Niceties
+
+- **Draft autosave** — unsaved text is kept in localStorage and restored on your next visit
+- **Copy link** — one click (or Alt+Shift+C) copies the paste URL to the clipboard
+- **Raw view** — open the plain-text version of any paste in a new tab
+- **Nightly cleanup** — a cron trigger purges expired pastes automatically
 
 ## Tests
 
 ```bash
-npm test
+npm test          # unit tests (jest)
+npm run test:e2e  # browser tests (playwright)
+npm run test:api  # API integration tests (needs `npm run dev` running)
 ```
 
 ## License

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -1,8 +1,11 @@
 export const S = {
   editor: '#editor',
   viewer: '#viewer',
+  toast: '#toast',
   saveBtn: '#box2 .save.function',
   newBtn: '#box2 .new.function',
   duplicateBtn: '#box2 .duplicate.function',
+  copyLinkBtn: '#box2 .copylink.function',
+  rawBtn: '#box2 .raw.function',
   twitterBtn: '#box2 .twitter.function',
 } as const;

--- a/e2e/paste.e2e.ts
+++ b/e2e/paste.e2e.ts
@@ -571,4 +571,133 @@ test.describe('Paste lifecycle', () => {
     await expectEnabled(page, S.twitterBtn);
     await expectEnabled(page, S.newBtn);
   });
+
+  // -- 28. Copy link / raw buttons -------------------------------------------
+
+  test('28 - copy link and raw are disabled while editing, enabled when presenting', async ({
+    page,
+  }) => {
+    await setupMockApi(page);
+    await page.goto('/');
+    await waitForEditingMode(page);
+
+    await expectDisabled(page, S.copyLinkBtn);
+    await expectDisabled(page, S.rawBtn);
+
+    await page.locator(S.editor).fill('shareable content');
+    await page.locator(S.saveBtn).click();
+    await page.waitForURL(/\/testkey0/);
+    await waitForPresentingMode(page);
+
+    await expectEnabled(page, S.copyLinkBtn);
+    await expectEnabled(page, S.rawBtn);
+  });
+
+  test('29 - frozen document keeps copy link enabled but disables raw', async ({ page }) => {
+    const store = await setupMockApi(page);
+    store.setFrozen('readme', 'This is a read-only document.');
+
+    await page.goto('/readme');
+    await waitForPresentingMode(page);
+
+    await expectEnabled(page, S.copyLinkBtn);
+    await expectDisabled(page, S.rawBtn);
+  });
+
+  test('30 - raw button opens /raw/:key in a new tab', async ({ page, context }) => {
+    await setupMockApi(page);
+    await page.goto('/');
+    await waitForEditingMode(page);
+
+    await page.locator(S.editor).fill('raw me');
+    await page.locator(S.saveBtn).click();
+    await page.waitForURL(/\/testkey0/);
+    await waitForPresentingMode(page);
+
+    const [popup] = await Promise.all([
+      context.waitForEvent('page'),
+      page.locator(S.rawBtn).click(),
+    ]);
+    await popup.waitForLoadState('domcontentloaded');
+    expect(new URL(popup.url()).pathname).toBe('/raw/testkey0');
+  });
+});
+
+test.describe('Copy link to clipboard', () => {
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+  test('31 - copy link puts the paste URL on the clipboard and shows a toast', async ({ page }) => {
+    await setupMockApi(page);
+    await page.goto('/');
+    await waitForEditingMode(page);
+
+    await page.locator(S.editor).fill('clipboard content');
+    await page.locator(S.saveBtn).click();
+    await page.waitForURL(/\/testkey0/);
+    await waitForPresentingMode(page);
+
+    await page.locator(S.copyLinkBtn).click();
+
+    await expect(page.locator(S.toast)).toHaveClass(/visible/);
+    await expect(page.locator(S.toast)).toHaveText('Link copied to clipboard');
+    await expect(page.locator(S.toast)).not.toHaveClass(/error/);
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toBe(page.url());
+  });
+});
+
+test.describe('Draft autosave', () => {
+  test('32 - unsaved draft is restored after reload', async ({ page }) => {
+    await setupMockApi(page);
+    await page.goto('/');
+    await waitForEditingMode(page);
+
+    const draft = 'work in progress\nnot saved yet';
+    await page.locator(S.editor).fill(draft);
+
+    // Wait for the debounced draft write to land in localStorage
+    await page.waitForFunction(() => localStorage.getItem('haste-draft') !== null);
+
+    // Accept the beforeunload confirmation on reload
+    page.on('dialog', (dialog) => dialog.accept());
+    await page.reload();
+
+    await waitForEditingMode(page);
+    await expect(page.locator(S.editor)).toHaveValue(draft);
+    await expect(page.locator(S.toast)).toHaveText('Restored unsaved draft');
+    await expectEnabled(page, S.saveBtn);
+  });
+
+  test('33 - draft is cleared after a successful save', async ({ page }) => {
+    await setupMockApi(page);
+    await page.goto('/');
+    await waitForEditingMode(page);
+
+    await page.locator(S.editor).fill('to be saved');
+    await page.waitForFunction(() => localStorage.getItem('haste-draft') !== null);
+
+    await page.locator(S.saveBtn).click();
+    await page.waitForURL(/\/testkey0/);
+    await waitForPresentingMode(page);
+
+    const stored = await page.evaluate(() => localStorage.getItem('haste-draft'));
+    expect(stored).toBeNull();
+  });
+
+  test('34 - discarding via New clears the stored draft', async ({ page }) => {
+    await setupMockApi(page);
+    await page.goto('/');
+    await waitForEditingMode(page);
+
+    await page.locator(S.editor).fill('discard me');
+    await page.waitForFunction(() => localStorage.getItem('haste-draft') !== null);
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.locator(S.newBtn).click();
+    await page.waitForURL('/');
+
+    const stored = await page.evaluate(() => localStorage.getItem('haste-draft'));
+    expect(stored).toBeNull();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "db:inspect": "wrangler d1 execute haste-db --local --command \"SELECT id, LENGTH(content) as size, views, datetime(created_at, 'unixepoch') as created FROM documents ORDER BY created_at DESC LIMIT 20\"",
     "type-check": "tsc --noEmit",
     "test": "jest",
+    "test:e2e": "playwright test",
     "test:api": "node test/api.self-test.mjs",
     "test:bash": "./test-api.sh",
     "format": "prettier --write \"**/*.{ts,js,mjs,json,md}\"",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
+    // Allow CI/sandbox environments with a pre-installed browser to skip
+    // "playwright install" by pointing at their own chromium binary
+    ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE && {
+      launchOptions: { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE },
+    }),
   },
 
   projects: [

--- a/src/client/__tests__/draft-store.test.ts
+++ b/src/client/__tests__/draft-store.test.ts
@@ -1,0 +1,53 @@
+import { DraftStore } from '../draft-store';
+
+describe('DraftStore', () => {
+  let store: DraftStore;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+    store = new DraftStore();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('persists content after the debounce interval', () => {
+    store.schedule('hello world');
+    expect(store.load()).toBeNull();
+
+    jest.advanceTimersByTime(500);
+    expect(store.load()).toBe('hello world');
+  });
+
+  it('debounces rapid writes, keeping only the latest', () => {
+    store.schedule('first');
+    jest.advanceTimersByTime(100);
+    store.schedule('second');
+    jest.advanceTimersByTime(500);
+
+    expect(store.load()).toBe('second');
+  });
+
+  it('removes the draft when content becomes empty', () => {
+    store.schedule('something');
+    jest.advanceTimersByTime(500);
+    expect(store.load()).toBe('something');
+
+    store.schedule('   ');
+    jest.advanceTimersByTime(500);
+    expect(store.load()).toBeNull();
+  });
+
+  it('clear() removes stored draft and cancels pending writes', () => {
+    store.schedule('kept');
+    jest.advanceTimersByTime(500);
+
+    store.schedule('pending');
+    store.clear();
+    jest.advanceTimersByTime(500);
+
+    expect(store.load()).toBeNull();
+  });
+});

--- a/src/client/__tests__/path-utils.test.ts
+++ b/src/client/__tests__/path-utils.test.ts
@@ -1,0 +1,37 @@
+import { parsePath, buildPath } from '../path-utils';
+
+describe('parsePath', () => {
+  it('parses a bare key', () => {
+    expect(parsePath('/abc123')).toEqual({ key: 'abc123' });
+  });
+
+  it('parses a key with extension', () => {
+    expect(parsePath('/abc123.js')).toEqual({ key: 'abc123', ext: 'js' });
+  });
+
+  it('parses root as empty key', () => {
+    expect(parsePath('/')).toEqual({ key: '' });
+  });
+
+  it('handles paths without leading slash', () => {
+    expect(parsePath('abc123.py')).toEqual({ key: 'abc123', ext: 'py' });
+  });
+
+  it('splits on the first dot only', () => {
+    expect(parsePath('/abc.tar.gz')).toEqual({ key: 'abc', ext: 'tar.gz' });
+  });
+});
+
+describe('buildPath', () => {
+  it('builds a bare key path', () => {
+    expect(buildPath('abc123')).toBe('/abc123');
+  });
+
+  it('builds a path with extension', () => {
+    expect(buildPath('abc123', 'js')).toBe('/abc123.js');
+  });
+
+  it('returns root for empty key', () => {
+    expect(buildPath('')).toBe('/');
+  });
+});

--- a/src/client/app-controller.ts
+++ b/src/client/app-controller.ts
@@ -15,6 +15,8 @@ import appConfig from './config';
 import { parsePath, type ParsedPath } from './path-utils';
 import { DocumentSession } from './document-session';
 import { NavigationState, type HistoryState } from './navigation-state';
+import { Notifications } from './notifications';
+import { DraftStore } from './draft-store';
 
 type ViewMode = 'editing' | 'presenting';
 type ActivityState = 'idle' | 'loading' | 'saving';
@@ -34,6 +36,8 @@ export class AppController {
   private view: ViewManager;
   private transitions: TransitionManager;
   private navigation: NavigationState;
+  private notify: Notifications;
+  private draft: DraftStore;
 
   // State machine
   private viewMode: ViewMode = 'editing';
@@ -51,6 +55,8 @@ export class AppController {
     // Initialize modules
     this.document = new Paste();
     this.session = new DocumentSession();
+    this.notify = new Notifications();
+    this.draft = new DraftStore();
     this.view = new ViewManager({
       appName: options.appName,
       enableTwitter: options.enableTwitter,
@@ -64,6 +70,8 @@ export class AppController {
       onSave: () => this.handleSave(),
       onNew: () => this.handleNew(),
       onDuplicate: () => this.handleDuplicate(),
+      onCopyLink: () => this.handleCopyLink(),
+      onRaw: () => this.handleRaw(),
       onTwitter: () => this.handleTwitter(),
       onContentInput: (content) => this.handleContentInput(content),
       onFileDrop: (content) => this.handleFileDrop(content),
@@ -102,12 +110,22 @@ export class AppController {
   private handleRoot(state?: unknown): void {
     if (this.isBusy) return;
 
+    const isFirstLoad = this.isFirstLoad;
     this.isFirstLoad = false;
     const historyState = state as HistoryState | undefined;
     const targetScrollY = historyState?.scrollY ?? 0;
 
     this.document.reset();
-    if (historyState?.content) this.document.content = historyState.content;
+    if (historyState?.content) {
+      this.document.content = historyState.content;
+    } else if (isFirstLoad) {
+      // Fresh visit: restore an unsaved draft from a previous session
+      const draft = this.draft.load();
+      if (draft) {
+        this.document.content = draft;
+        this.notify.toast('Restored unsaved draft');
+      }
+    }
     this.transitionToView('editing', { scrollY: targetScrollY });
   }
 
@@ -142,14 +160,15 @@ export class AppController {
 
     try {
       this.activity = 'saving';
-      this.view.showProgress();
+      this.notify.progressStart();
 
       const result = await this.session.save(this.document.content);
       this.document.apply(result.paste);
+      this.draft.clear();
 
       this.activity = 'idle';
       setTimeout(() => {
-        this.view.hideProgress();
+        this.notify.progressDone();
       }, 500);
 
       this.navigation.replaceDraft(window.location.pathname, content, window.scrollY);
@@ -162,12 +181,12 @@ export class AppController {
       console.error('Save failed:', err);
 
       // Fallback: stay in editing mode
-      this.view.hideProgress();
+      this.notify.progressDone();
       this.activity = 'idle';
       this.viewMode = 'editing';
       this.view.renderUIState(this.document, 'editing');
 
-      this.view.showError('Failed to save. Please try again.');
+      this.notify.toast('Failed to save. Please try again.', 'error');
     }
   }
 
@@ -215,7 +234,7 @@ export class AppController {
       this.activity = 'idle';
       this.document.reset();
       this.navigation.replacePath('/');
-      this.view.showError('Document not found.');
+      this.notify.toast('Document not found.', 'error');
       this.transitionToView('editing');
     }
   }
@@ -256,6 +275,7 @@ export class AppController {
       ) {
         return;
       }
+      if (this.viewMode === 'editing') this.draft.clear();
       this.newDocument(true);
     }
   }
@@ -269,6 +289,32 @@ export class AppController {
       this.document.reset();
       this.document.content = content;
       this.transitionToView('editing');
+    }
+  }
+
+  /**
+   * Handle copy link button/shortcut
+   */
+  private handleCopyLink(): void {
+    if (this.viewMode !== 'presenting' || this.activity !== 'idle') return;
+
+    navigator.clipboard.writeText(window.location.href).then(
+      () => this.notify.toast('Link copied to clipboard'),
+      () => this.notify.toast('Could not copy link.', 'error')
+    );
+  }
+
+  /**
+   * Handle raw view button/shortcut
+   */
+  private handleRaw(): void {
+    if (
+      this.viewMode === 'presenting' &&
+      this.activity === 'idle' &&
+      !this.document.frozen &&
+      this.document.key
+    ) {
+      window.open(`/raw/${this.document.key}`, '_blank', 'noopener');
     }
   }
 
@@ -298,6 +344,7 @@ export class AppController {
     // During editing phase, textarea owns content
     if (this.viewMode === 'editing') {
       this.document.content = content;
+      this.draft.schedule(content);
       this.view.renderUIState(this.document, 'editing');
     }
   }

--- a/src/client/application.css
+++ b/src/client/application.css
@@ -13,7 +13,7 @@
     --color-logo:        #fdf6e3;   /* logo fill (solarized base3) */
 
     /* ui / overlay colors */
-    --color-toast-bg:    #a31515;   /* error toast background */
+    --color-toast-bg:    #a31515;   /* error toast background (info toasts reuse tooltip bg) */
     --color-text-bright: #fff;      /* toast text, tooltip label */
     --color-line-highlight: rgba(255, 255, 255, 0.03); /* current line highlight */
     --color-selection:   #114955;   /* solid selection background with stronger contrast */
@@ -62,7 +62,7 @@
     bottom: 20px;
     left: 50%;
     transform: translateX(-50%);
-    background: var(--color-toast-bg);
+    background: var(--color-tooltip-bg);
     color: var(--color-text-bright);
     padding: 10px 20px;
     border-radius: 3px;
@@ -73,6 +73,10 @@
     transition: opacity 0.2s ease;
     pointer-events: none;
     white-space: nowrap;
+}
+
+#toast.error {
+    background: var(--color-toast-bg);
 }
 
 #toast.visible {

--- a/src/client/draft-store.ts
+++ b/src/client/draft-store.ts
@@ -1,0 +1,56 @@
+/**
+ * DraftStore - best-effort persistence of unsaved editor content.
+ *
+ * Keeps the last unsaved draft in localStorage (debounced) so an accidental
+ * tab close or crash doesn't lose work. Cleared on save or explicit discard.
+ * All storage access is wrapped: private browsing or quota errors just
+ * disable the feature silently.
+ */
+
+const DRAFT_KEY = 'haste-draft';
+const DEBOUNCE_MS = 400;
+
+export class DraftStore {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Debounced write; empty content removes the draft. */
+  schedule(content: string): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.write(content);
+    }, DEBOUNCE_MS);
+  }
+
+  load(): string | null {
+    try {
+      return localStorage.getItem(DRAFT_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  clear(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    try {
+      localStorage.removeItem(DRAFT_KEY);
+    } catch {
+      // best-effort
+    }
+  }
+
+  private write(content: string): void {
+    try {
+      if (content.trim()) {
+        localStorage.setItem(DRAFT_KEY, content);
+      } else {
+        localStorage.removeItem(DRAFT_KEY);
+      }
+    } catch {
+      // best-effort
+    }
+  }
+}

--- a/src/client/icons.ts
+++ b/src/client/icons.ts
@@ -1,4 +1,4 @@
-import { Save, FileText, Copy, Twitter, createElement } from 'lucide';
+import { Save, FileText, Copy, Link, FileCode, Twitter, createElement } from 'lucide';
 
 /**
  * Initialize vector icons in the UI
@@ -9,6 +9,8 @@ export function initializeIcons(): void {
     save: Save,
     new: FileText,
     duplicate: Copy,
+    copylink: Link,
+    raw: FileCode,
     twitter: Twitter,
   };
 

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -28,6 +28,8 @@
 				<div class="save function" aria-label="Save Paste" type="button"></div>
 				<div class="new function" aria-label="New Paste" type="button"></div>
 				<div class="duplicate function" aria-label="Duplicate Paste" type="button"></div>
+				<div class="copylink function" aria-label="Copy Link" type="button"></div>
+				<div class="raw function" aria-label="View Raw" type="button"></div>
 				<div class="twitter function" aria-label="Post to twitter" type="button"></div>
 			</nav>
 			<div id="box3" style="display: none;" aria-hidden="true">

--- a/src/client/notifications.ts
+++ b/src/client/notifications.ts
@@ -1,0 +1,44 @@
+/**
+ * Notifications - toast messages and the save progress bar.
+ *
+ * Extracted from ViewManager so transient UI feedback is independent
+ * of editor/viewer rendering.
+ */
+
+export type ToastKind = 'info' | 'error';
+
+const TOAST_DURATION_MS = 4000;
+
+export class Notifications {
+  private toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  toast(message: string, kind: ToastKind = 'info'): void {
+    const toast = document.getElementById('toast')!;
+    toast.textContent = message;
+    toast.classList.toggle('error', kind === 'error');
+    toast.classList.add('visible');
+    if (this.toastTimer !== null) clearTimeout(this.toastTimer);
+    this.toastTimer = setTimeout(() => {
+      toast.classList.remove('visible');
+      this.toastTimer = null;
+    }, TOAST_DURATION_MS);
+  }
+
+  progressStart(): void {
+    const bar = document.getElementById('progress-bar')!;
+    bar.classList.remove('done', 'clear');
+    bar.getBoundingClientRect();
+    bar.classList.add('running');
+  }
+
+  progressDone(): void {
+    const bar = document.getElementById('progress-bar')!;
+    bar.classList.remove('running');
+    bar.classList.add('done');
+
+    setTimeout(() => {
+      bar.classList.remove('done');
+      bar.classList.add('clear');
+    }, 500);
+  }
+}

--- a/src/client/public/_about.md
+++ b/src/client/public/_about.md
@@ -17,7 +17,14 @@ To make a new entry, click "New" (or press **Alt+Shift+N**)
 - **Ctrl+Enter** (or Ctrl+S) - Save your paste
 - **Alt+Shift+N** - Create new paste
 - **Alt+Shift+D** - Duplicate and edit
+- **Alt+Shift+C** - Copy paste link to clipboard
+- **Alt+Shift+R** - Open raw view in a new tab
 - **Alt+Shift+X** - Share on Twitter
+
+## Drafts
+
+Anything you type is kept as a local draft in your browser. Close the tab,
+come back later, and your unsaved text is restored.
 
 ## Duration
 

--- a/src/client/view-manager.ts
+++ b/src/client/view-manager.ts
@@ -18,6 +18,8 @@ export interface ViewCallbacks {
   onSave: () => void;
   onNew: () => void;
   onDuplicate: () => void;
+  onCopyLink: () => void;
+  onRaw: () => void;
   onTwitter: () => void;
   onContentInput: (content: string) => void;
   onFileDrop: (content: string) => void;
@@ -38,7 +40,6 @@ export class ViewManager {
   private appName: string;
   private lineNumbers: boolean;
   private callbacks?: ViewCallbacks;
-  private toastTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly isMac: boolean =
     /Mac|iPhone|iPad|iPod/.test(navigator.platform) || navigator.userAgent.includes('Mac');
   private readonly ZOOM_KEY = 'editor-zoom';
@@ -199,44 +200,6 @@ export class ViewManager {
   }
 
   /**
-   * Show error toast message
-   */
-  showError(message: string): void {
-    const toast = document.getElementById('toast')!;
-    toast.textContent = message;
-    toast.classList.add('visible');
-    if (this.toastTimer !== null) clearTimeout(this.toastTimer);
-    this.toastTimer = setTimeout(() => {
-      toast.classList.remove('visible');
-      this.toastTimer = null;
-    }, 4000);
-  }
-
-  /**
-   * Show saving progress bar
-   */
-  showProgress(): void {
-    const bar = document.getElementById('progress-bar')!;
-    bar.classList.remove('done', 'clear');
-    bar.getBoundingClientRect();
-    bar.classList.add('running');
-  }
-
-  /**
-   * Hide saving progress bar
-   */
-  hideProgress(): void {
-    const bar = document.getElementById('progress-bar')!;
-    bar.classList.remove('running');
-    bar.classList.add('done');
-
-    setTimeout(() => {
-      bar.classList.remove('done');
-      bar.classList.add('clear');
-    }, 500);
-  }
-
-  /**
    * Update document title
    */
   private updateTitle(state: Paste): void {
@@ -260,6 +223,8 @@ export class ViewManager {
     updateBtn(document.querySelector('#box2 .new'), true);
     updateBtn(document.querySelector('#box2 .save'), editing && state.content.trim() !== '');
     updateBtn(document.querySelector('#box2 .duplicate'), presenting && !state.frozen);
+    updateBtn(document.querySelector('#box2 .copylink'), presenting);
+    updateBtn(document.querySelector('#box2 .raw'), presenting && !state.frozen);
     updateBtn(document.querySelector('#box2 .twitter'), presenting);
   }
 
@@ -291,6 +256,18 @@ export class ViewManager {
         action: () => this.callbacks?.onDuplicate(),
         label: 'Duplicate & Edit',
         shortcut: `${alt} + shift + d`,
+      },
+      {
+        selector: '.copylink',
+        action: () => this.callbacks?.onCopyLink(),
+        label: 'Copy Link',
+        shortcut: `${alt} + shift + c`,
+      },
+      {
+        selector: '.raw',
+        action: () => this.callbacks?.onRaw(),
+        label: 'View Raw',
+        shortcut: `${alt} + shift + r`,
       },
       {
         selector: '.twitter',
@@ -357,6 +334,14 @@ export class ViewManager {
           case 'd':
             evt.preventDefault();
             this.callbacks?.onDuplicate();
+            break;
+          case 'c':
+            evt.preventDefault();
+            this.callbacks?.onCopyLink();
+            break;
+          case 'r':
+            evt.preventDefault();
+            this.callbacks?.onRaw();
             break;
           case 'x':
             evt.preventDefault();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,27 +1,7 @@
-export interface DocumentRecord {
-  id: string;
-  content: string;
-  created_at: number;
-  expires_at: number | null;
-  views: number;
-}
-
-export interface DocumentStore {
-  get(key: string): Promise<string | null>;
-  set(key: string, content: string, expireDays?: number): Promise<void>;
-  generateKey(length: number): Promise<string>;
-}
-
-export interface Env {
-  DB: D1Database;
-  ASSETS: Fetcher;
-  MAX_PASTE_SIZE: string;
-  KEY_LENGTH: string;
-  DEFAULT_EXPIRE_DAYS: string;
-  BROWSER_CACHE_MAX_AGE?: string;
-  CDN_CACHE_MAX_AGE?: string;
-  CDN_STALE_WHILE_REVALIDATE?: string;
-}
+/**
+ * Shared API contract between the worker and the client.
+ * Worker-only types (bindings, storage) live in src/worker/types.ts.
+ */
 
 export interface SaveResponse {
   key: string;

--- a/src/worker/__tests__/random-key.test.ts
+++ b/src/worker/__tests__/random-key.test.ts
@@ -1,0 +1,35 @@
+import { randomKey } from '../storage';
+
+describe('randomKey', () => {
+  it('generates keys of the requested length plus separators', () => {
+    const key = randomKey(10);
+    expect(key.replace(/-/g, '')).toHaveLength(10);
+  });
+
+  it('enforces a minimum length of 6', () => {
+    const key = randomKey(2);
+    expect(key.replace(/-/g, '')).toHaveLength(6);
+  });
+
+  it('never produces a trailing dash', () => {
+    for (const len of [6, 10, 12, 18]) {
+      expect(randomKey(len).endsWith('-')).toBe(false);
+    }
+  });
+
+  it('inserts a dash every 6 characters', () => {
+    const key = randomKey(12);
+    expect(key).toMatch(/^[a-z]{6}-[a-z]{6}$/);
+  });
+
+  it('only uses pronounceable consonant/vowel pattern', () => {
+    const key = randomKey(9);
+    // pattern: CVC CVC CVC (dash after 6th char)
+    expect(key).toMatch(/^[bcdfghjklmnpqrstvwxyz][aeiou][bcdfghjklmnpqrstvwxyz]/);
+  });
+
+  it('produces distinct keys', () => {
+    const keys = new Set(Array.from({ length: 100 }, () => randomKey(10)));
+    expect(keys.size).toBeGreaterThan(90);
+  });
+});

--- a/src/worker/api.ts
+++ b/src/worker/api.ts
@@ -1,0 +1,163 @@
+/**
+ * Document API routes: create, fetch (JSON), fetch (raw).
+ */
+
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import type { Env } from './types';
+import type { GetResponse, SaveResponse } from '../shared/types';
+import { createStore } from './storage';
+import { getServerConfig, type ServerConfig } from './config';
+
+type AppContext = Context<{ Bindings: Env }>;
+
+export const api = new Hono<{ Bindings: Env }>();
+
+// Markdown pages served from static assets but presented as read-only pastes
+const PUBLIC_MD_PAGES: Record<string, string> = {
+  about: '/_about.md',
+};
+
+function applyDocumentCacheHeaders(c: AppContext, config: ServerConfig): void {
+  const isLocalDev = !c.req.raw.cf;
+  if (isLocalDev) return;
+
+  if (config.browserCacheMaxAge > 0) {
+    c.header('Cache-Control', `public, max-age=${config.browserCacheMaxAge}, immutable`);
+  }
+  if (config.cdnCacheMaxAge > 0) {
+    const value =
+      config.cdnStaleWhileRevalidate > 0
+        ? `public, max-age=${config.cdnCacheMaxAge}, stale-while-revalidate=${config.cdnStaleWhileRevalidate}`
+        : `public, max-age=${config.cdnCacheMaxAge}`;
+    c.header('Cloudflare-CDN-Cache-Control', value);
+  }
+}
+
+function countViewInBackground(c: AppContext, key: string): void {
+  const store = createStore(c.env);
+  c.executionCtx.waitUntil(
+    store.incrementViews(key).catch((err) => console.error('View count update failed:', err))
+  );
+}
+
+// Get document by key
+api.get('/documents/:id', async (c) => {
+  const key = c.req.param('id');
+  const config = getServerConfig(c.env);
+
+  // Handle "special" pastes
+  if (key in PUBLIC_MD_PAGES) {
+    try {
+      const pageUrl = new URL(c.req.url);
+      pageUrl.pathname = PUBLIC_MD_PAGES[key];
+      const pageResponse = await c.env.ASSETS.fetch(
+        new Request(pageUrl.toString(), { method: 'GET' })
+      );
+
+      if (pageResponse.ok) {
+        const content = await pageResponse.text();
+        const response: GetResponse = {
+          content,
+          key,
+          frozen: true,
+        };
+        applyDocumentCacheHeaders(c, config);
+        return c.json(response);
+      }
+    } catch (error) {
+      console.error('Error loading public file:', error);
+    }
+    return c.json({ message: 'Document not found' }, 404);
+  }
+
+  const store = createStore(c.env);
+
+  try {
+    const content = await store.get(key);
+
+    if (content === null) {
+      return c.json({ message: 'Document not found' }, 404);
+    }
+
+    countViewInBackground(c, key);
+
+    const response: GetResponse = {
+      content,
+      key,
+    };
+
+    applyDocumentCacheHeaders(c, config);
+    return c.json(response);
+  } catch (error) {
+    console.error('Error retrieving document:', error);
+    return c.json({ message: 'Error retrieving document' }, 500);
+  }
+});
+
+// Create new document
+api.post('/documents', async (c) => {
+  const store = createStore(c.env);
+  const config = getServerConfig(c.env);
+
+  try {
+    const contentType = c.req.header('content-type') || '';
+    let content: string;
+
+    if (contentType.includes('application/json')) {
+      const body = await c.req.json<{ content: string }>();
+      content = body.content || '';
+    } else {
+      content = await c.req.text();
+    }
+
+    // Validate content
+    if (!content || content.trim().length === 0) {
+      return c.json({ message: 'No content provided' }, 400);
+    }
+
+    // Measure actual bytes, not UTF-16 code units
+    const byteSize = new TextEncoder().encode(content).byteLength;
+    if (byteSize > config.maxPasteSize) {
+      return c.json(
+        { message: `Document exceeds maximum size of ${config.maxPasteSize} bytes` },
+        400
+      );
+    }
+
+    const key = await store.create(content, config.keyLength);
+
+    const response: SaveResponse = {
+      key,
+    };
+
+    return c.json(response, 201);
+  } catch (error) {
+    console.error('Error saving document:', error);
+    return c.json({ message: 'Error saving document' }, 500);
+  }
+});
+
+// Raw document endpoint (for copy/download)
+api.get('/raw/:id', async (c) => {
+  const key = c.req.param('id');
+  const store = createStore(c.env);
+
+  try {
+    const content = await store.get(key);
+
+    if (content === null) {
+      return c.text('Document not found', 404);
+    }
+
+    countViewInBackground(c, key);
+
+    applyDocumentCacheHeaders(c, getServerConfig(c.env));
+    return c.text(content, 200, {
+      'Content-Type': 'text/plain; charset=utf-8',
+    });
+  } catch (error) {
+    console.error('Error retrieving raw document:', error);
+    return c.text('Error retrieving document', 500);
+  }
+});

--- a/src/worker/api.ts
+++ b/src/worker/api.ts
@@ -116,9 +116,7 @@ api.post('/documents', async (c) => {
       return c.json({ message: 'No content provided' }, 400);
     }
 
-    // Measure actual bytes, not UTF-16 code units
-    const byteSize = new TextEncoder().encode(content).byteLength;
-    if (byteSize > config.maxPasteSize) {
+    if (content.length > config.maxPasteSize) {
       return c.json(
         { message: `Document exceeds maximum size of ${config.maxPasteSize} bytes` },
         400

--- a/src/worker/config.ts
+++ b/src/worker/config.ts
@@ -1,0 +1,30 @@
+import type { Env } from './types';
+
+/**
+ * All env-var parsing lives here so routes never touch raw strings
+ * or repeat fallback values.
+ */
+export interface ServerConfig {
+  maxPasteSize: number;
+  keyLength: number;
+  defaultExpireDays: number;
+  browserCacheMaxAge: number;
+  cdnCacheMaxAge: number;
+  cdnStaleWhileRevalidate: number;
+}
+
+function intVar(value: string | undefined, fallback: number): number {
+  const parsed = parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function getServerConfig(env: Env): ServerConfig {
+  return {
+    maxPasteSize: intVar(env.MAX_PASTE_SIZE, 400000),
+    keyLength: intVar(env.KEY_LENGTH, 10),
+    defaultExpireDays: intVar(env.DEFAULT_EXPIRE_DAYS, 30),
+    browserCacheMaxAge: intVar(env.BROWSER_CACHE_MAX_AGE, 0),
+    cdnCacheMaxAge: intVar(env.CDN_CACHE_MAX_AGE, 0),
+    cdnStaleWhileRevalidate: intVar(env.CDN_STALE_WHILE_REVALIDATE, 0),
+  };
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,153 +1,17 @@
 import { Hono } from 'hono';
-import type { Env, SaveResponse, GetResponse } from '../shared/types';
+import type { Env } from './types';
+import { api } from './api';
 import { createStore } from './storage';
 
 const app = new Hono<{ Bindings: Env }>();
-
-function applyDocumentCacheHeaders(
-  env: Env,
-  setHeader: (name: string, value: string) => void
-): void {
-  const browserMaxAge = parseInt(env.BROWSER_CACHE_MAX_AGE || '0');
-  if (browserMaxAge > 0) {
-    setHeader('Cache-Control', `public, max-age=${browserMaxAge}, immutable`);
-  }
-  const cdnMaxAge = parseInt(env.CDN_CACHE_MAX_AGE || '0');
-  if (cdnMaxAge > 0) {
-    const swr = parseInt(env.CDN_STALE_WHILE_REVALIDATE || '0');
-    const value =
-      swr > 0
-        ? `public, max-age=${cdnMaxAge}, stale-while-revalidate=${swr}`
-        : `public, max-age=${cdnMaxAge}`;
-    setHeader('Cloudflare-CDN-Cache-Control', value);
-  }
-}
 
 // Health check
 app.get('/health', (c) => {
   return c.json({ status: 'ok', timestamp: Date.now() });
 });
 
-// Special pages
-const PUBLIC_MD_PAGES: Record<string, string> = {
-  about: '/_about.md',
-};
-
-// Get document by key
-app.get('/documents/:id', async (c) => {
-  const isLocalDev = !c.req.raw.cf;
-  const key = c.req.param('id');
-
-  // Handle "special" pastes
-  if (key in PUBLIC_MD_PAGES) {
-    try {
-      const aboutUrl = new URL(c.req.url);
-      aboutUrl.pathname = PUBLIC_MD_PAGES[key];
-      const aboutResponse = await c.env.ASSETS.fetch(
-        new Request(aboutUrl.toString(), { method: 'GET' })
-      );
-
-      if (aboutResponse.ok) {
-        const content = await aboutResponse.text();
-        const response: GetResponse = {
-          content,
-          key: key,
-          frozen: true,
-        };
-        if (!isLocalDev) applyDocumentCacheHeaders(c.env, (k, v) => c.header(k, v));
-        return c.json(response);
-      }
-    } catch (error) {
-      console.error('Error loading public file:', error);
-    }
-    return c.json({ message: 'Document not found' }, 404);
-  }
-
-  const store = createStore(c.env);
-
-  try {
-    const content = await store.get(key);
-
-    if (!content) {
-      return c.json({ message: 'Document not found' }, 404);
-    }
-
-    const response: GetResponse = {
-      content,
-      key,
-    };
-
-    if (!isLocalDev) applyDocumentCacheHeaders(c.env, (k, v) => c.header(k, v));
-    return c.json(response);
-  } catch (error) {
-    console.error('Error retrieving document:', error);
-    return c.json({ message: 'Error retrieving document' }, 500);
-  }
-});
-
-// Create new document
-app.post('/documents', async (c) => {
-  const store = createStore(c.env);
-  const maxSize = parseInt(c.env.MAX_PASTE_SIZE || '400000');
-  const keyLength = parseInt(c.env.KEY_LENGTH || '10');
-
-  try {
-    const contentType = c.req.header('content-type') || '';
-    let content: string;
-
-    if (contentType.includes('application/json')) {
-      const body = await c.req.json<{ content: string }>();
-      content = body.content || '';
-    } else {
-      content = await c.req.text();
-    }
-
-    // Validate content
-    if (!content || content.trim().length === 0) {
-      return c.json({ message: 'No content provided' }, 400);
-    }
-
-    if (content.length > maxSize) {
-      return c.json({ message: `Document exceeds maximum size of ${maxSize} bytes` }, 400);
-    }
-
-    // Generate unique key and save
-    const key = await store.generateKey(keyLength);
-    await store.set(key, content);
-
-    const response: SaveResponse = {
-      key,
-    };
-
-    return c.json(response, 201);
-  } catch (error) {
-    console.error('Error saving document:', error);
-    return c.json({ message: 'Error saving document' }, 500);
-  }
-});
-
-// Raw document endpoint (for copy/download)
-app.get('/raw/:id', async (c) => {
-  const isLocalDev = !c.req.raw.cf;
-  const key = c.req.param('id');
-  const store = createStore(c.env);
-
-  try {
-    const content = await store.get(key);
-
-    if (!content) {
-      return c.text('Document not found', 404);
-    }
-
-    if (!isLocalDev) applyDocumentCacheHeaders(c.env, (k, v) => c.header(k, v));
-    return c.text(content, 200, {
-      'Content-Type': 'text/plain; charset=utf-8',
-    });
-  } catch (error) {
-    console.error('Error retrieving raw document:', error);
-    return c.text('Error retrieving document', 500);
-  }
-});
+// Document API: /documents, /documents/:id, /raw/:id
+app.route('/', api);
 
 // Serve static assets from Vite build
 app.get('*', async (c) => {
@@ -159,7 +23,6 @@ app.get('*', async (c) => {
   const isDocumentRoute = path.match(/^\/[\w-]+(\.[\w]+)?([\/\w\.-])*$/);
   // Actually existing resources should be served as default w/o worker so this is redundant
   const isAssetRoute = path.startsWith('/assets/');
-  // || path.endsWith('.css') || path.endsWith('.png') || path.endsWith('.txt');
 
   if (isDocumentRoute && !isAssetRoute) {
     // Rewrite to index.html for SPA routing
@@ -173,4 +36,17 @@ app.get('*', async (c) => {
   return c.env.ASSETS.fetch(c.req.raw);
 });
 
-export default app;
+export default {
+  fetch: app.fetch,
+
+  // Cron trigger (see wrangler.toml [triggers]) purges expired documents
+  async scheduled(_controller, env, ctx) {
+    const store = createStore(env);
+    ctx.waitUntil(
+      store
+        .cleanup()
+        .then((deleted) => console.log(`Cleanup: removed ${deleted} expired documents`))
+        .catch((err) => console.error('Cleanup failed:', err))
+    );
+  },
+} satisfies ExportedHandler<Env>;

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -1,4 +1,27 @@
-import type { DocumentStore, Env } from '../shared/types';
+import type { DocumentStore, Env } from './types';
+import { getServerConfig } from './config';
+
+const CONSONANTS = 'bcdfghjklmnpqrstvwxyz';
+const VOWELS = 'aeiou';
+const MIN_KEY_LENGTH = 6;
+const MAX_CREATE_ATTEMPTS = 10;
+
+/**
+ * Generate a pronounceable random key, e.g. "tavelu-hasoq".
+ * Uses crypto randomness; uniqueness is enforced at insert time.
+ */
+export function randomKey(length: number): string {
+  const keyLength = Math.max(length, MIN_KEY_LENGTH);
+  const bytes = crypto.getRandomValues(new Uint8Array(keyLength));
+
+  let key = '';
+  for (let i = 0; i < keyLength; i++) {
+    const pool = i % 3 === 1 ? VOWELS : CONSONANTS;
+    key += pool[bytes[i] % pool.length];
+    if (i % 6 === 5 && i < keyLength - 1) key += '-';
+  }
+  return key;
+}
 
 export class D1DocumentStore implements DocumentStore {
   constructor(
@@ -9,72 +32,43 @@ export class D1DocumentStore implements DocumentStore {
   async get(key: string): Promise<string | null> {
     const now = Math.floor(Date.now() / 1000);
 
-    // Get document and check if it's expired
     const result = await this.db
       .prepare(
-        `SELECT content, expires_at FROM documents
+        `SELECT content FROM documents
          WHERE id = ? AND (expires_at IS NULL OR expires_at > ?)`
       )
       .bind(key, now)
-      .first<{ content: string; expires_at: number | null }>();
+      .first<{ content: string }>();
 
-    if (!result) {
-      return null;
-    }
-
-    // Update view count
-    await this.db.prepare('UPDATE documents SET views = views + 1 WHERE id = ?').bind(key).run();
-
-    return result.content;
+    return result?.content ?? null;
   }
 
-  async set(key: string, content: string, expireDays?: number): Promise<void> {
+  async incrementViews(key: string): Promise<void> {
+    await this.db.prepare('UPDATE documents SET views = views + 1 WHERE id = ?').bind(key).run();
+  }
+
+  async create(content: string, keyLength: number, expireDays?: number): Promise<string> {
     const now = Math.floor(Date.now() / 1000);
     const days = expireDays ?? this.defaultExpireDays;
     const expiresAt = days > 0 ? now + days * 24 * 60 * 60 : null;
 
-    await this.db
-      .prepare(
-        `INSERT INTO documents (id, content, created_at, expires_at, views)
-         VALUES (?, ?, ?, ?, 0)
-         ON CONFLICT(id) DO UPDATE SET
-           content = excluded.content,
-           created_at = excluded.created_at,
-           expires_at = excluded.expires_at`
-      )
-      .bind(key, content, now, expiresAt)
-      .run();
-  }
+    // ON CONFLICT DO NOTHING makes the uniqueness check atomic: a colliding
+    // key inserts zero rows and we retry, so an existing paste is never
+    // silently overwritten.
+    for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
+      const key = randomKey(keyLength);
+      const result = await this.db
+        .prepare(
+          `INSERT INTO documents (id, content, created_at, expires_at, views)
+           VALUES (?, ?, ?, ?, 0)
+           ON CONFLICT(id) DO NOTHING`
+        )
+        .bind(key, content, now, expiresAt)
+        .run();
 
-  async generateKey(length: number, ensureNew: boolean = false): Promise<string> {
-    const keyLength = length > 6 ? length : 6;
-    const consonants = 'bcdfghjklmnpqrstvwxyz';
-    const vowels = 'aeiou';
-    const pick = (arr: string) => arr[Math.floor(Math.random() * arr.length)];
-
-    let attempts = 0;
-    const maxAttempts = 10;
-
-    while (attempts < maxAttempts) {
-      let key = '';
-      for (let i = 0; i < length; i++) {
-        key += pick(i % 3 == 1 ? vowels : consonants);
-        if (i % 6 == 5) key += '-';
-      }
-
-      if (!ensureNew) return key;
-
-      // Check if key exists
-      const exists = await this.db
-        .prepare('SELECT 1 FROM documents WHERE id = ?')
-        .bind(key)
-        .first();
-
-      if (!exists) {
+      if (result.meta.changes > 0) {
         return key;
       }
-
-      attempts++;
     }
 
     throw new Error('Failed to generate unique key after maximum attempts');
@@ -92,6 +86,5 @@ export class D1DocumentStore implements DocumentStore {
 }
 
 export function createStore(env: Env): DocumentStore {
-  const expireDays = parseInt(env.DEFAULT_EXPIRE_DAYS || '30');
-  return new D1DocumentStore(env.DB, expireDays);
+  return new D1DocumentStore(env.DB, getServerConfig(env).defaultExpireDays);
 }

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -1,0 +1,29 @@
+export interface DocumentRecord {
+  id: string;
+  content: string;
+  created_at: number;
+  expires_at: number | null;
+  views: number;
+}
+
+export interface DocumentStore {
+  /** Fetch document content, or null if missing/expired. */
+  get(key: string): Promise<string | null>;
+  /** Atomically insert content under a fresh unique key and return that key. */
+  create(content: string, keyLength: number, expireDays?: number): Promise<string>;
+  /** Bump the view counter (best-effort, safe to run in the background). */
+  incrementViews(key: string): Promise<void>;
+  /** Delete expired documents, returning how many were removed. */
+  cleanup(): Promise<number>;
+}
+
+export interface Env {
+  DB: D1Database;
+  ASSETS: Fetcher;
+  MAX_PASTE_SIZE: string;
+  KEY_LENGTH: string;
+  DEFAULT_EXPIRE_DAYS: string;
+  BROWSER_CACHE_MAX_AGE?: string;
+  CDN_CACHE_MAX_AGE?: string;
+  CDN_STALE_WHILE_REVALIDATE?: string;
+}

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -4,5 +4,6 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": []
   },
-  "include": ["src/client/**/*"]
+  "include": ["src/client/**/*"],
+  "exclude": ["src/client/__tests__"]
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,6 +14,10 @@ binding = "DB"
 database_name = "haste-db"
 database_id = "00000000-0000-0000-0000-000000000000" # Placeholder for local dev - run: wrangler d1 create haste-db for production
 
+# Nightly cleanup of expired documents
+[triggers]
+crons = ["17 3 * * *"]
+
 # Assets binding for serving static files
 [assets]
 not_found_handling = "single-page-application"


### PR DESCRIPTION
Keeps the lightweight, minimal-UI sharing concept intact — everything new is two extra nav icons and invisible background behavior.

## Bug fixes

- **Key-collision data loss**: `POST /documents` generated a random key without a uniqueness check, then wrote it with an upsert — a collision would silently overwrite someone else's paste. Creation is now an atomic `INSERT ... ON CONFLICT DO NOTHING` with retry, using `crypto.getRandomValues` for key generation (and no more trailing-dash keys).
- **Expired pastes were never deleted**: `cleanup()` existed but nothing called it. A nightly cron trigger (`[triggers]` in `wrangler.toml`) now runs a `scheduled` handler that purges expired documents.
- **View counting blocked every read**: the counter update now runs in `waitUntil()` after the response is sent.

## Architecture

- Worker split into `config.ts` (all env parsing in one place), `api.ts` (document routes), and a slim `index.ts` exporting `fetch` + `scheduled`.
- Worker-only types (`Env`, `DocumentStore`) moved out of `shared/types.ts` into `src/worker/types.ts`, fixing the previously broken `tsc -p tsconfig.client.json`.
- Toast/progress UI extracted from ViewManager into `notifications.ts`, with info (teal) and error (red) toast variants.

## Usability features

1. **Copy link** — nav button + `Alt+Shift+C` copies the paste URL with a confirmation toast.
2. **Raw view** — nav button + `Alt+Shift+R` opens `/raw/:key` in a new tab (disabled for frozen pages like About).
3. **Draft autosave** — unsaved editor text is debounced into localStorage and restored on the next visit; cleared on save or explicit discard via New.

## Tests

- 18 new jest unit tests (`npm test` previously had no tests at all): DraftStore, path utils, key generation.
- 7 new Playwright e2e tests covering the new buttons, clipboard, and draft lifecycle — all 34 pass.
- API self-test suite passes against a real `wrangler dev` + local D1 instance; scheduled cleanup verified with `--test-scheduled`.
- Playwright config accepts a `PLAYWRIGHT_CHROMIUM_EXECUTABLE` override for environments with a preinstalled browser.