### PR TITLE
Harden paste creation, rendering, and URL IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,16 @@ Your instance will be live at `https://haste.YOUR-SUBDOMAIN.workers.dev`.
 
 Edit `wrangler.toml` vars:
 
-| Variable              | Default | Description             |
-| --------------------- | ------- | ----------------------- |
-| `MAX_PASTE_SIZE`      | 400000  | Max paste size in bytes |
-| `KEY_LENGTH`          | 10      | Length of paste IDs     |
-| `DEFAULT_EXPIRE_DAYS` | 30      | Days until expiration   |
+| Variable              | Default       | Description                                                    |
+| --------------------- | ------------- | -------------------------------------------------------------- |
+| `MAX_PASTE_SIZE`      | 400000        | Max paste size in bytes                                        |
+| `KEY_LENGTH`          | 10            | Length of paste IDs                                            |
+| `KEY_STRATEGY`        | pronounceable | Paste ID format: `pronounceable`, URL-safe `random`, or `uuid` |
+| `DEFAULT_EXPIRE_DAYS` | 30            | Days until expiration                                          |
+
+`KEY_LENGTH` applies to `pronounceable` and `random` IDs. Random IDs carry six bits of
+entropy per character; UUID IDs use `crypto.randomUUID()` and ignore `KEY_LENGTH`.
+Creation and read limits are configured by the two `ratelimits` bindings in `wrangler.toml`.
 
 ## API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "highlight.js": "^11.10.0",
-        "hono": "^4.6.3",
+        "hono": "^4.13.0",
         "lucide": "^0.562.0"
       },
       "devDependencies": {
@@ -4545,9 +4545,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "highlight.js": "^11.10.0",
-    "hono": "^4.6.3",
+    "hono": "^4.13.0",
     "lucide": "^0.562.0"
   },
   "devDependencies": {

--- a/src/client/__tests__/highlight-config.test.ts
+++ b/src/client/__tests__/highlight-config.test.ts
@@ -1,0 +1,31 @@
+import {
+  getLanguageForExtension,
+  highlightContent,
+  MAX_AUTO_HIGHLIGHT_LENGTH,
+  MAX_EXPLICIT_HIGHLIGHT_LENGTH,
+} from '../highlight-config';
+
+describe('highlight policy', () => {
+  it('treats unknown extensions as unknown rather than throwing', () => {
+    expect(getLanguageForExtension('xyz-not-registered')).toBeUndefined();
+    expect(getLanguageForExtension('__proto__')).toBeUndefined();
+  });
+
+  it('escapes HTML when content is too large for automatic detection', () => {
+    const content = '<script>alert(1)</script>' + 'x'.repeat(MAX_AUTO_HIGHLIGHT_LENGTH);
+    const result = highlightContent(content);
+
+    expect(result.highlighted).toContain('&lt;script&gt;');
+    expect(result.highlighted).not.toContain('<script>');
+    expect(result.language).toBeUndefined();
+  });
+
+  it('bounds explicit highlighting independently', () => {
+    const content = '<img onerror=alert(1)>' + 'x'.repeat(MAX_EXPLICIT_HIGHLIGHT_LENGTH);
+    const result = highlightContent(content, 'xml');
+
+    expect(result.highlighted).toContain('&lt;img');
+    expect(result.highlighted).not.toContain('<img');
+    expect(result.language).toBe('xml');
+  });
+});

--- a/src/client/highlight-config.ts
+++ b/src/client/highlight-config.ts
@@ -164,6 +164,9 @@ export const extensionMap: Record<string, string> = {
   txt: '',
 };
 
+export const MAX_AUTO_HIGHLIGHT_LENGTH = 10_000;
+export const MAX_EXPLICIT_HIGHLIGHT_LENGTH = 50_000;
+
 /**
  * Language Utilities
  */
@@ -172,7 +175,8 @@ export const extensionMap: Record<string, string> = {
  * Get language for file extension
  */
 export function getLanguageForExtension(ext: string): string | undefined {
-  return extensionMap[ext] || ext;
+  const normalized = ext.toLowerCase();
+  return Object.hasOwn(extensionMap, normalized) ? extensionMap[normalized] : undefined;
 }
 
 /**
@@ -207,8 +211,21 @@ export function highlightContent(content: string, language?: string): HighlightR
     };
   }
 
+  const canUseLanguage = language && hljs.getLanguage(language);
+
+  // Highlighting is synchronous. Bound attacker-controlled work so opening a
+  // large paste cannot freeze the viewer tab.
+  if (
+    content.length > (canUseLanguage ? MAX_EXPLICIT_HIGHLIGHT_LENGTH : MAX_AUTO_HIGHLIGHT_LENGTH)
+  ) {
+    return {
+      highlighted: escapeHtml(content),
+      language: canUseLanguage ? language : undefined,
+    };
+  }
+
   // Language specified - use it directly
-  if (language) {
+  if (canUseLanguage) {
     const result = hljs.highlight(content, { language });
     return {
       highlighted: result.value,

--- a/src/worker/__tests__/api-validation.test.ts
+++ b/src/worker/__tests__/api-validation.test.ts
@@ -1,0 +1,92 @@
+/** @jest-environment node */
+
+import { api } from '../api';
+import type { Env } from '../types';
+
+const env = {
+  MAX_PASTE_SIZE: '4',
+  KEY_LENGTH: '10',
+  DEFAULT_EXPIRE_DAYS: '30',
+} as Env;
+
+describe('document API validation', () => {
+  it('rejects malformed JSON as a client error', async () => {
+    const response = await api.request(
+      '/documents',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{',
+      },
+      env
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ message: 'Invalid JSON body' });
+  });
+
+  it('requires JSON content to be a string', async () => {
+    const response = await api.request(
+      '/documents',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 123 }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      message: 'JSON body must contain a string content field',
+    });
+  });
+
+  it('enforces paste size in UTF-8 bytes', async () => {
+    const response = await api.request(
+      '/documents',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: '€€',
+      },
+      env
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Document exceeds maximum size of 4 bytes',
+    });
+  });
+
+  it('creates IDs using the configured strategy', async () => {
+    const db = {
+      prepare: jest.fn(() => ({
+        bind: jest.fn(() => ({
+          run: jest.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        })),
+      })),
+    } as unknown as D1Database;
+
+    const response = await api.request(
+      '/documents',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'hello',
+      },
+      {
+        ...env,
+        DB: db,
+        MAX_PASTE_SIZE: '100',
+        KEY_LENGTH: '16',
+        KEY_STRATEGY: 'random',
+      }
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      key: expect.stringMatching(/^[A-Za-z0-9_-]{16}$/),
+    });
+  });
+});

--- a/src/worker/__tests__/random-key.test.ts
+++ b/src/worker/__tests__/random-key.test.ts
@@ -1,35 +1,47 @@
-import { randomKey } from '../storage';
+/** @jest-environment node */
+
+import { generateKey, pronounceableKey, urlSafeKey } from '../storage';
 
 describe('randomKey', () => {
   it('generates keys of the requested length plus separators', () => {
-    const key = randomKey(10);
+    const key = pronounceableKey(10);
     expect(key.replace(/-/g, '')).toHaveLength(10);
   });
 
   it('enforces a minimum length of 6', () => {
-    const key = randomKey(2);
+    const key = pronounceableKey(2);
     expect(key.replace(/-/g, '')).toHaveLength(6);
   });
 
   it('never produces a trailing dash', () => {
     for (const len of [6, 10, 12, 18]) {
-      expect(randomKey(len).endsWith('-')).toBe(false);
+      expect(pronounceableKey(len).endsWith('-')).toBe(false);
     }
   });
 
   it('inserts a dash every 6 characters', () => {
-    const key = randomKey(12);
+    const key = pronounceableKey(12);
     expect(key).toMatch(/^[a-z]{6}-[a-z]{6}$/);
   });
 
   it('only uses pronounceable consonant/vowel pattern', () => {
-    const key = randomKey(9);
+    const key = pronounceableKey(9);
     // pattern: CVC CVC CVC (dash after 6th char)
     expect(key).toMatch(/^[bcdfghjklmnpqrstvwxyz][aeiou][bcdfghjklmnpqrstvwxyz]/);
   });
 
   it('produces distinct keys', () => {
-    const keys = new Set(Array.from({ length: 100 }, () => randomKey(10)));
+    const keys = new Set(Array.from({ length: 100 }, () => pronounceableKey(10)));
     expect(keys.size).toBeGreaterThan(90);
+  });
+
+  it('generates URL-safe random keys at six bits per character', () => {
+    expect(urlSafeKey(16)).toMatch(/^[A-Za-z0-9_-]{16}$/);
+  });
+
+  it('supports UUID keys independently of configured length', () => {
+    expect(generateKey('uuid', 6)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
   });
 });

--- a/src/worker/__tests__/request-policy.test.ts
+++ b/src/worker/__tests__/request-policy.test.ts
@@ -1,0 +1,98 @@
+/** @jest-environment node */
+
+import { Hono } from 'hono';
+import { installRequestPolicy } from '../request-policy';
+import type { Env } from '../types';
+
+function limiter(success = true): RateLimit {
+  return {
+    limit: jest.fn().mockResolvedValue({ success }),
+  };
+}
+
+function testEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    MAX_PASTE_SIZE: '10',
+    KEY_LENGTH: '10',
+    DEFAULT_EXPIRE_DAYS: '30',
+    CREATE_RATE_LIMITER: limiter(),
+    READ_RATE_LIMITER: limiter(),
+    ...overrides,
+  } as Env;
+}
+
+function testApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  installRequestPolicy(app);
+  app.get('/ok', (c) => c.text('ok'));
+  app.get('/redirect', () => Response.redirect('https://example.com'));
+  app.get('/documents/:id', (c) => c.text(c.req.param('id')));
+  app.post('/documents', async (c) => c.text(await c.req.text()));
+  return app;
+}
+
+describe('request policy', () => {
+  it('adds lightweight security headers globally', async () => {
+    const response = await testApp().request('/ok', {}, testEnv());
+
+    expect(response.headers.get('content-security-policy')).toContain("default-src 'self'");
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(response.headers.get('x-frame-options')).toBe('DENY');
+    expect(response.headers.get('referrer-policy')).toBe('no-referrer');
+  });
+
+  it('can add headers to responses whose original headers are immutable', async () => {
+    const response = await testApp().request('/redirect', {}, testEnv());
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+  });
+
+  it('rejects cross-origin browser document creation', async () => {
+    const env = testEnv();
+    const response = await testApp().request(
+      'https://haste.example/documents',
+      {
+        method: 'POST',
+        headers: { Origin: 'https://attacker.example' },
+        body: 'hello',
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(env.CREATE_RATE_LIMITER.limit).not.toHaveBeenCalled();
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+  });
+
+  it('permits non-browser API clients without an Origin header', async () => {
+    const response = await testApp().request(
+      'https://haste.example/documents',
+      { method: 'POST', body: 'hello' },
+      testEnv()
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it('rejects request bodies before an unbounded read', async () => {
+    const response = await testApp().request(
+      'https://haste.example/documents',
+      { method: 'POST', body: 'x'.repeat(11) },
+      testEnv()
+    );
+
+    expect(response.status).toBe(413);
+  });
+
+  it('returns 429 when the read limiter denies a request', async () => {
+    const response = await testApp().request(
+      'https://haste.example/documents/known-key',
+      {},
+      testEnv({ READ_RATE_LIMITER: limiter(false) })
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('retry-after')).toBe('60');
+  });
+});

--- a/src/worker/api.ts
+++ b/src/worker/api.ts
@@ -47,7 +47,7 @@ api.get('/documents/:id', async (c) => {
   const config = getServerConfig(c.env);
 
   // Handle "special" pastes
-  if (key in PUBLIC_MD_PAGES) {
+  if (Object.hasOwn(PUBLIC_MD_PAGES, key)) {
     try {
       const pageUrl = new URL(c.req.url);
       pageUrl.pathname = PUBLIC_MD_PAGES[key];
@@ -105,8 +105,21 @@ api.post('/documents', async (c) => {
     let content: string;
 
     if (contentType.includes('application/json')) {
-      const body = await c.req.json<{ content: string }>();
-      content = body.content || '';
+      let body: unknown;
+      try {
+        body = await c.req.json<unknown>();
+      } catch {
+        return c.json({ message: 'Invalid JSON body' }, 400);
+      }
+
+      if (
+        !body ||
+        typeof body !== 'object' ||
+        typeof (body as { content?: unknown }).content !== 'string'
+      ) {
+        return c.json({ message: 'JSON body must contain a string content field' }, 400);
+      }
+      content = (body as { content: string }).content;
     } else {
       content = await c.req.text();
     }
@@ -116,14 +129,18 @@ api.post('/documents', async (c) => {
       return c.json({ message: 'No content provided' }, 400);
     }
 
-    if (content.length > config.maxPasteSize) {
+    const contentBytes = new TextEncoder().encode(content).byteLength;
+    if (contentBytes > config.maxPasteSize) {
       return c.json(
         { message: `Document exceeds maximum size of ${config.maxPasteSize} bytes` },
         400
       );
     }
 
-    const key = await store.create(content, config.keyLength);
+    const key = await store.create(content, {
+      strategy: config.keyStrategy,
+      length: config.keyLength,
+    });
 
     const response: SaveResponse = {
       key,

--- a/src/worker/config.ts
+++ b/src/worker/config.ts
@@ -1,4 +1,4 @@
-import type { Env } from './types';
+import type { Env, KeyStrategy } from './types';
 
 /**
  * All env-var parsing lives here so routes never touch raw strings
@@ -7,10 +7,17 @@ import type { Env } from './types';
 export interface ServerConfig {
   maxPasteSize: number;
   keyLength: number;
+  keyStrategy: KeyStrategy;
   defaultExpireDays: number;
   browserCacheMaxAge: number;
   cdnCacheMaxAge: number;
   cdnStaleWhileRevalidate: number;
+}
+
+function keyStrategyVar(value: string | undefined): KeyStrategy {
+  return value === 'random' || value === 'uuid' || value === 'pronounceable'
+    ? value
+    : 'pronounceable';
 }
 
 function intVar(value: string | undefined, fallback: number): number {
@@ -22,6 +29,7 @@ export function getServerConfig(env: Env): ServerConfig {
   return {
     maxPasteSize: intVar(env.MAX_PASTE_SIZE, 400000),
     keyLength: intVar(env.KEY_LENGTH, 10),
+    keyStrategy: keyStrategyVar(env.KEY_STRATEGY),
     defaultExpireDays: intVar(env.DEFAULT_EXPIRE_DAYS, 30),
     browserCacheMaxAge: intVar(env.BROWSER_CACHE_MAX_AGE, 0),
     cdnCacheMaxAge: intVar(env.CDN_CACHE_MAX_AGE, 0),

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -2,8 +2,11 @@ import { Hono } from 'hono';
 import type { Env } from './types';
 import { api } from './api';
 import { createStore } from './storage';
+import { installRequestPolicy } from './request-policy';
 
 const app = new Hono<{ Bindings: Env }>();
+
+installRequestPolicy(app);
 
 // Health check
 app.get('/health', (c) => {

--- a/src/worker/request-policy.ts
+++ b/src/worker/request-policy.ts
@@ -1,0 +1,114 @@
+import type { Hono, MiddlewareHandler } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { getServerConfig } from './config';
+import type { Env } from './types';
+
+type App = { Bindings: Env };
+
+const JSON_ENCODING_EXPANSION = 6;
+const JSON_ENVELOPE_BYTES = 1024;
+
+const SECURITY_HEADERS = {
+  'Content-Security-Policy':
+    "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; " +
+    "form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; " +
+    "img-src 'self' data:; connect-src 'self'",
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Resource-Policy': 'same-origin',
+  'Origin-Agent-Cluster': '?1',
+  'Permissions-Policy': 'camera=(), geolocation=(), microphone=()',
+  'Referrer-Policy': 'no-referrer',
+  'Strict-Transport-Security': 'max-age=15552000; includeSubDomains',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+} as const;
+
+const addSecurityHeaders: MiddlewareHandler<App> = async (c, next) => {
+  await next();
+
+  // Responses returned by fetch bindings (including ASSETS) can have immutable
+  // headers. Clone once at the boundary before applying the global policy.
+  const response = new Response(c.res.body, c.res);
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    response.headers.set(name, value);
+  }
+  c.res = response;
+};
+
+function isDocumentWrite(path: string, method: string): boolean {
+  return method === 'POST' && path === '/documents';
+}
+
+function isDocumentRead(path: string, method: string): boolean {
+  return method === 'GET' && /^\/(?:documents|raw)\/[^/]+$/.test(path);
+}
+
+function isCrossOriginBrowserWrite(request: Request): boolean {
+  if (request.headers.get('sec-fetch-site') === 'cross-site') return true;
+
+  const origin = request.headers.get('origin');
+  if (!origin) return false; // Non-browser clients such as curl do not send Origin.
+
+  try {
+    return new URL(origin).origin !== new URL(request.url).origin;
+  } catch {
+    return true;
+  }
+}
+
+function rateLimitKey(request: Request): string {
+  // This service has no accounts or API keys, so the connecting IP is the
+  // least-bad coarse identity available. Keep configured limits NAT-friendly.
+  return request.headers.get('cf-connecting-ip') || 'unknown-client';
+}
+
+async function checkRateLimit(c: Parameters<MiddlewareHandler<App>>[0], limiter: RateLimit) {
+  try {
+    const { success } = await limiter.limit({ key: rateLimitKey(c.req.raw) });
+    if (success) return null;
+
+    c.header('Retry-After', '60');
+    return c.json({ message: 'Too many requests' }, 429);
+  } catch (error) {
+    console.error('Rate limit check failed:', error);
+    return c.json({ message: 'Request policy unavailable' }, 503);
+  }
+}
+
+const enforceRequestPolicy: MiddlewareHandler<App> = async (c, next) => {
+  const path = c.req.path;
+  const method = c.req.method;
+
+  if (isDocumentWrite(path, method)) {
+    if (isCrossOriginBrowserWrite(c.req.raw)) {
+      return c.json({ message: 'Cross-origin document creation is not allowed' }, 403);
+    }
+
+    const limited = await checkRateLimit(c, c.env.CREATE_RATE_LIMITER);
+    if (limited) return limited;
+
+    // JSON string escaping can expand one decoded content byte to six request
+    // bytes (for example, "\u0000"). The route enforces the exact decoded byte
+    // limit after parsing; this guard prevents unbounded buffering beforehand.
+    const maxPasteSize = getServerConfig(c.env).maxPasteSize;
+    const isJson = (c.req.header('content-type') || '').toLowerCase().includes('application/json');
+    return bodyLimit({
+      maxSize: isJson ? maxPasteSize * JSON_ENCODING_EXPANSION + JSON_ENVELOPE_BYTES : maxPasteSize,
+      onError: (context) => context.json({ message: 'Request body is too large' }, 413),
+    })(c, next);
+  }
+
+  if (isDocumentRead(path, method)) {
+    const limited = await checkRateLimit(c, c.env.READ_RATE_LIMITER);
+    if (limited) return limited;
+  }
+
+  await next();
+};
+
+/** Install the complete HTTP boundary policy in one place. */
+export function installRequestPolicy(app: Hono<App>): void {
+  // Register security headers first so they are also applied to policy errors.
+  app.use('*', addSecurityHeaders);
+  app.use('*', enforceRequestPolicy);
+}

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -1,16 +1,17 @@
-import type { DocumentStore, Env } from './types';
+import type { DocumentStore, Env, KeyOptions, KeyStrategy } from './types';
 import { getServerConfig } from './config';
 
 const CONSONANTS = 'bcdfghjklmnpqrstvwxyz';
 const VOWELS = 'aeiou';
 const MIN_KEY_LENGTH = 6;
 const MAX_CREATE_ATTEMPTS = 10;
+const URL_SAFE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
 
 /**
  * Generate a pronounceable random key, e.g. "tavelu-hasoq".
  * Uses crypto randomness; uniqueness is enforced at insert time.
  */
-export function randomKey(length: number): string {
+export function pronounceableKey(length: number): string {
   const keyLength = Math.max(length, MIN_KEY_LENGTH);
   const bytes = crypto.getRandomValues(new Uint8Array(keyLength));
 
@@ -21,6 +22,24 @@ export function randomKey(length: number): string {
     if (i % 6 === 5 && i < keyLength - 1) key += '-';
   }
   return key;
+}
+
+/** Generate a URL-safe key with six bits of entropy per character. */
+export function urlSafeKey(length: number): string {
+  const keyLength = Math.max(length, MIN_KEY_LENGTH);
+  const bytes = crypto.getRandomValues(new Uint8Array(keyLength));
+  return Array.from(bytes, (byte) => URL_SAFE_ALPHABET[byte & 63]).join('');
+}
+
+export function generateKey(strategy: KeyStrategy, length: number): string {
+  switch (strategy) {
+    case 'random':
+      return urlSafeKey(length);
+    case 'uuid':
+      return crypto.randomUUID();
+    case 'pronounceable':
+      return pronounceableKey(length);
+  }
 }
 
 export class D1DocumentStore implements DocumentStore {
@@ -47,7 +66,7 @@ export class D1DocumentStore implements DocumentStore {
     await this.db.prepare('UPDATE documents SET views = views + 1 WHERE id = ?').bind(key).run();
   }
 
-  async create(content: string, keyLength: number, expireDays?: number): Promise<string> {
+  async create(content: string, keyOptions: KeyOptions, expireDays?: number): Promise<string> {
     const now = Math.floor(Date.now() / 1000);
     const days = expireDays ?? this.defaultExpireDays;
     const expiresAt = days > 0 ? now + days * 24 * 60 * 60 : null;
@@ -56,7 +75,7 @@ export class D1DocumentStore implements DocumentStore {
     // key inserts zero rows and we retry, so an existing paste is never
     // silently overwritten.
     for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
-      const key = randomKey(keyLength);
+      const key = generateKey(keyOptions.strategy, keyOptions.length);
       const result = await this.db
         .prepare(
           `INSERT INTO documents (id, content, created_at, expires_at, views)

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -10,11 +10,18 @@ export interface DocumentStore {
   /** Fetch document content, or null if missing/expired. */
   get(key: string): Promise<string | null>;
   /** Atomically insert content under a fresh unique key and return that key. */
-  create(content: string, keyLength: number, expireDays?: number): Promise<string>;
+  create(content: string, keyOptions: KeyOptions, expireDays?: number): Promise<string>;
   /** Bump the view counter (best-effort, safe to run in the background). */
   incrementViews(key: string): Promise<void>;
   /** Delete expired documents, returning how many were removed. */
   cleanup(): Promise<number>;
+}
+
+export type KeyStrategy = 'pronounceable' | 'random' | 'uuid';
+
+export interface KeyOptions {
+  strategy: KeyStrategy;
+  length: number;
 }
 
 export interface Env {
@@ -23,7 +30,10 @@ export interface Env {
   MAX_PASTE_SIZE: string;
   KEY_LENGTH: string;
   DEFAULT_EXPIRE_DAYS: string;
+  KEY_STRATEGY?: string;
   BROWSER_CACHE_MAX_AGE?: string;
   CDN_CACHE_MAX_AGE?: string;
   CDN_STALE_WHILE_REVALIDATE?: string;
+  CREATE_RATE_LIMITER: RateLimit;
+  READ_RATE_LIMITER: RateLimit;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,7 +28,25 @@ binding = "ASSETS"
 [vars]
 MAX_PASTE_SIZE = "400000"
 KEY_LENGTH = "10"
+KEY_STRATEGY = "pronounceable"             # pronounceable | random | uuid
 DEFAULT_EXPIRE_DAYS = "30"
 BROWSER_CACHE_MAX_AGE = "3600"        # browser Cache-Control max-age in seconds; "0" to disable
 CDN_CACHE_MAX_AGE = "2592000"         # CF edge Cloudflare-CDN-Cache-Control max-age in seconds; "0" to disable
 CDN_STALE_WHILE_REVALIDATE = "86400"  # stale-while-revalidate for CF edge; "0" to omit
+
+# Coarse abuse protection. Namespace IDs only need to be unique within this account.
+[[ratelimits]]
+name = "CREATE_RATE_LIMITER"
+namespace_id = "81234001"
+
+  [ratelimits.simple]
+  limit = 30
+  period = 60
+
+[[ratelimits]]
+name = "READ_RATE_LIMITER"
+namespace_id = "81234002"
+
+  [ratelimits.simple]
+  limit = 300
+  period = 60


### PR DESCRIPTION
## Summary

- centralize request-boundary policy for body limits, same-origin browser writes, Cloudflare-native rate limits, and security headers
- validate JSON payloads and enforce paste limits using UTF-8 byte size
- add configurable `pronounceable`, URL-safe `random`, and `uuid` ID strategies
- bound synchronous syntax highlighting and safely fall back to escaped plain text
- update Hono to 4.13.0

## Why

The adversarial source review found inexpensive resource-exhaustion paths in anonymous document reads and writes, unbounded request buffering, and client-side denial of service through automatic syntax highlighting. It also found that the existing pronounceable IDs offered limited entropy when links were treated as unlisted.

This keeps the app's architecture small: HTTP boundary concerns live in one Worker policy module, while highlighting policy remains in the existing client highlighting module.

## Impact

Existing deployments retain pronounceable IDs by default. Operators can select higher-entropy URL-safe IDs or UUIDs through `KEY_STRATEGY`. Wrangler now declares separate creation and read rate-limit bindings.

Cross-origin browser document creation is rejected, while command-line clients without an `Origin` header continue to work.

## Validation

- 33 unit tests
- 34 Playwright end-to-end tests
- TypeScript type-check
- production Vite build
- Wrangler deployment dry-run
- production dependency audit: zero vulnerabilities
